### PR TITLE
[feature] Input 컴포넌트 구현 (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ storybook-static
 .env
 .env.development
 .env.production
+
+/coverage
+.claude/

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,7 +7,7 @@ import GlobalStyle from "../src/styles/globals/globalStyle";
 export const decorators = [
   (Story) => (
     <ThemeProvider theme={theme}>
-      <div style={{ backgroundColor: "#222222", height: "100w" }}>
+      <div style={{ backgroundColor: theme.colors.background, height: "100w" }}>
         <GlobalStyle />
         <Story />
       </div>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,29 @@ npx @biomejs/biome format .    # 포맷팅
 npx @biomejs/biome check --write .  # 자동 수정
 ```
 
+### Figma 디자인 구현 (MCP 연동)
+Figma MCP를 통해 디자인을 코드로 변환할 수 있습니다.
+
+#### URL 형식
+```
+https://figma.com/design/:fileKey/:fileName?node-id=:nodeId
+```
+
+#### 구현 프로세스
+1. **Figma URL 제공**: 구현할 컴포넌트의 Figma URL 전달
+2. **디자인 컨텍스트 조회**: MCP를 통해 디자인 정보, 스타일, 에셋 URL 추출
+3. **컴포넌트 구현**: 프로젝트 컨벤션에 맞게 코드 생성
+   - `Component.tsx` + `Component.styles.ts` 분리
+   - Emotion styled components 사용
+   - 접근성(a11y) 속성 포함
+4. **Storybook 스토리 작성**: 다양한 상태의 Story 생성
+
+#### 사용 가능한 MCP 도구
+- `get_design_context`: 디자인 정보 및 코드 생성
+- `get_screenshot`: 노드 스크린샷 생성
+- `get_variable_defs`: 디자인 변수(색상, 폰트 등) 조회
+- `get_metadata`: 노드 구조 메타데이터 조회
+
 ## 주요 라이브러리 사용법
 
 ### Emotion Styled Components

--- a/src/components/ui/input/Input.styles.ts
+++ b/src/components/ui/input/Input.styles.ts
@@ -1,38 +1,7 @@
 import styled from "@emotion/styled";
-import type { CSSObject } from "@emotion/react";
+import { hexToRgba } from "../../../utils/hexToRgba";
 
 type InputVariant = "default" | "error" | "success";
-
-const getVariantStyles = (
-  variant: InputVariant,
-  colors: Record<string, string>,
-): CSSObject => {
-  const styles: Record<InputVariant, CSSObject> = {
-    default: {
-      borderColor: colors.gray500,
-      "&:focus": {
-        borderColor: colors.primary,
-        outline: "none",
-      },
-    },
-    error: {
-      borderColor: colors.error,
-      "&:focus": {
-        borderColor: colors.error,
-        outline: "none",
-      },
-    },
-    success: {
-      borderColor: colors.success,
-      "&:focus": {
-        borderColor: colors.success,
-        outline: "none",
-      },
-    },
-  };
-
-  return styles[variant];
-};
 
 export const Wrapper = styled.div`
   display: flex;
@@ -55,25 +24,31 @@ export const RequiredMark = styled.span`
 
 export const InputField = styled.input<{ variant: InputVariant }>`
   width: 100%;
-  padding: 12px 16px;
+  padding: 12px 8px;
   border-radius: 8px;
-  border: 1px solid;
-  background-color: transparent;
-  font-size: ${({ theme }) => theme.typography.body2.size};
-  font-weight: ${({ theme }) => theme.typography.body2.weight};
-  line-height: ${({ theme }) => theme.typography.body2.lineHeight};
+  border: none;
+  background-color: ${({ theme }) => hexToRgba(theme.colors.gray900, 0.7)};
+  font-size: ${({ theme }) => theme.typography.body1.size};
+  font-weight: ${({ theme }) => theme.typography.body1.weight};
+  line-height: ${({ theme }) => theme.typography.body1.lineHeight};
+  letter-spacing: -0.4px;
   color: ${({ theme }) => theme.colors.white};
-  transition: border-color 0.2s ease;
 
-  ${({ theme, variant }) => getVariantStyles(variant, theme.colors)};
+  &:focus {
+    outline: ${({ theme, variant }) => {
+      if (variant === "error") return `2px solid ${theme.colors.error}`;
+      if (variant === "success") return `2px solid ${theme.colors.success}`;
+      return `2px solid ${theme.colors.primary}`;
+    }};
+    outline-offset: -2px;
+  }
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.gray500};
   }
 
   &:disabled {
-    background-color: ${({ theme }) => theme.colors.gray900};
-    color: ${({ theme }) => theme.colors.gray500};
+    opacity: 0.5;
     cursor: not-allowed;
   }
 `;

--- a/src/components/ui/input/Input.styles.ts
+++ b/src/components/ui/input/Input.styles.ts
@@ -1,0 +1,91 @@
+import styled from "@emotion/styled";
+import type { CSSObject } from "@emotion/react";
+
+type InputVariant = "default" | "error" | "success";
+
+const getVariantStyles = (
+  variant: InputVariant,
+  colors: Record<string, string>,
+): CSSObject => {
+  const styles: Record<InputVariant, CSSObject> = {
+    default: {
+      borderColor: colors.gray500,
+      "&:focus": {
+        borderColor: colors.primary,
+        outline: "none",
+      },
+    },
+    error: {
+      borderColor: colors.error,
+      "&:focus": {
+        borderColor: colors.error,
+        outline: "none",
+      },
+    },
+    success: {
+      borderColor: colors.success,
+      "&:focus": {
+        borderColor: colors.success,
+        outline: "none",
+      },
+    },
+  };
+
+  return styles[variant];
+};
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+`;
+
+export const Label = styled.label`
+  font-size: ${({ theme }) => theme.typography.body1.size};
+  font-weight: ${({ theme }) => theme.typography.body1.weight};
+  line-height: ${({ theme }) => theme.typography.body1.lineHeight};
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const RequiredMark = styled.span`
+  color: ${({ theme }) => theme.colors.error};
+  margin-left: 4px;
+`;
+
+export const InputField = styled.input<{ variant: InputVariant }>`
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid;
+  background-color: transparent;
+  font-size: ${({ theme }) => theme.typography.body2.size};
+  font-weight: ${({ theme }) => theme.typography.body2.weight};
+  line-height: ${({ theme }) => theme.typography.body2.lineHeight};
+  color: ${({ theme }) => theme.colors.white};
+  transition: border-color 0.2s ease;
+
+  ${({ theme, variant }) => getVariantStyles(variant, theme.colors)};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray500};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.gray900};
+    color: ${({ theme }) => theme.colors.gray500};
+    cursor: not-allowed;
+  }
+`;
+
+export const HelperText = styled.p<{ variant: InputVariant }>`
+  font-size: ${({ theme }) => theme.typography.caption.size};
+  font-weight: ${({ theme }) => theme.typography.caption.weight};
+  line-height: ${({ theme }) => theme.typography.caption.lineHeight};
+  color: ${({ theme, variant }) => {
+    if (variant === "error") return theme.colors.error;
+    if (variant === "success") return theme.colors.success;
+    return theme.colors.gray500;
+  }};
+  margin: 0;
+`;

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -1,0 +1,55 @@
+import type { InputHTMLAttributes } from "react";
+import * as S from "./Input.styles";
+
+type InputVariant = "default" | "error" | "success";
+
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  /** 입력 필드 라벨 */
+  label?: string;
+  /** 에러 또는 도움말 메시지 */
+  helperText?: string;
+  /** 입력 필드 상태 */
+  variant?: InputVariant;
+  /** 필수 입력 여부 */
+  required?: boolean;
+}
+
+const Input = ({
+  label,
+  helperText,
+  variant = "default",
+  required = false,
+  id,
+  disabled,
+  ...rest
+}: InputProps) => {
+  const inputId = id || `input-${Math.random().toString(36).substring(2, 9)}`;
+  const helperTextId = helperText ? `${inputId}-helper` : undefined;
+
+  return (
+    <S.Wrapper>
+      {label && (
+        <S.Label htmlFor={inputId}>
+          {label}
+          {required && <S.RequiredMark aria-hidden="true">*</S.RequiredMark>}
+        </S.Label>
+      )}
+      <S.InputField
+        id={inputId}
+        variant={variant}
+        disabled={disabled}
+        aria-invalid={variant === "error"}
+        aria-describedby={helperTextId}
+        aria-required={required}
+        {...rest}
+      />
+      {helperText && (
+        <S.HelperText id={helperTextId} variant={variant}>
+          {helperText}
+        </S.HelperText>
+      )}
+    </S.Wrapper>
+  );
+};
+
+export default Input;

--- a/src/stories/components/Input.stories.tsx
+++ b/src/stories/components/Input.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Input from "../../components/ui/input/Input";
+
+const meta: Meta<typeof Input> = {
+  title: "Component/Input",
+  component: Input,
+  argTypes: {
+    label: {
+      control: "text",
+      description: "입력 필드 라벨",
+    },
+    placeholder: {
+      control: "text",
+      description: "플레이스홀더 텍스트",
+    },
+    helperText: {
+      control: "text",
+      description: "에러 또는 도움말 메시지",
+    },
+    variant: {
+      control: "select",
+      options: ["default", "error", "success"],
+      description: "입력 필드 상태",
+    },
+    required: {
+      control: "boolean",
+      description: "필수 입력 여부",
+    },
+    disabled: {
+      control: "boolean",
+      description: "비활성화 여부",
+    },
+    type: {
+      control: "select",
+      options: ["text", "email", "password", "number", "tel"],
+      description: "입력 타입",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "텍스트를 입력해주세요",
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: "이메일",
+    placeholder: "example@email.com",
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: "이름",
+    placeholder: "이름을 입력해주세요",
+    required: true,
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    label: "비밀번호",
+    type: "password",
+    placeholder: "비밀번호를 입력해주세요",
+    helperText: "8자 이상, 영문과 숫자를 포함해주세요",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: "이메일",
+    placeholder: "example@email.com",
+    value: "invalid-email",
+    variant: "error",
+    helperText: "올바른 이메일 형식이 아닙니다",
+  },
+};
+
+export const Success: Story = {
+  args: {
+    label: "닉네임",
+    placeholder: "닉네임을 입력해주세요",
+    value: "사용가능한닉네임",
+    variant: "success",
+    helperText: "사용 가능한 닉네임입니다",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: "이메일",
+    placeholder: "example@email.com",
+    value: "disabled@email.com",
+    disabled: true,
+  },
+};
+
+export const Password: Story = {
+  args: {
+    label: "비밀번호",
+    type: "password",
+    placeholder: "비밀번호를 입력해주세요",
+    required: true,
+  },
+};


### PR DESCRIPTION
## 📌 요약
Input 컴포넌트를 새롭게 구현했습니다.

## ✨ 변경 사항
- **Input 컴포넌트** 구현
-   - 라벨, 헬퍼 텍스트, 필수 표시 등을 포함한 완전한 입력 필드
-   - 3가지 variant 지원: `default`, `error`, `success`
-   - 필수 입력 여부 표시 가능
-   - Emotion 스타일링으로 테마 연동
-   - 완전한 접근성 속성 지원 (aria-invalid, aria-required, aria-describedby)
- **Input 스토리북** 추가
-   - Default, WithLabel, Required, WithHelperText, Error, Success, Disabled, Password 등 8가지 예제 제공
- **.gitignore** 업데이트
-   - coverage 폴더 및 .claude 폴더 추가
- .claude : skills 명령어에 활용되는 md 파일들 
- coverage : 테스트 커버리지 로그