### PR TITLE
[docs] UI/컴포넌트 이슈 템플릿 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/ui_implementation.yml
+++ b/.github/ISSUE_TEMPLATE/ui_implementation.yml
@@ -20,11 +20,12 @@ body:
         - 코드 + 테스트
         - 코드 + 테스트 + 스토리북
 
-  - type: input
+  - type: textarea
     id: figma
     attributes:
       label: Figma URL
-      placeholder: "https://figma.com/design/:fileKey/:fileName?node-id=:nodeId"
+      description: "variant별로 한 줄씩 작성 (예: primary: URL)"
+      placeholder: "primary: https://figma.com/design/:fileKey/:fileName?node-id=:nodeId"
     validations:
       required: false
 


### PR DESCRIPTION
## 📌 요약
UI/컴포넌트 이슈 템플릿의 Figma URL 필드가 input 타입이라 URL을 하나만 첨부할 수 있었습니다. 
이로 인해 다양한 variant의 컴포넌트를 구현할 때, AI가 요청사항을 명확하게 이해할 수 있도록 이슈를 작성하는 것이 어렵다는 문제가 있었습니다.         
   
따라서 UI/컴포넌트 이슈 템플릿을 다양한 variant를 가진 컴포넌트를 구현할 때에도 작성하기 용이하고, AI가 명확하게 요청사항을 파악해서 구현할 수 있도록 수정했습니다.

## ✨ 변경 사항
- UI/컴포넌트 이슈 템플릿 내부의 'Figma URL'의 type을 input 에서 textarea 로 변경함                                  
- placeholder를 사용해 요청사항 입력 전 적절한 예시를 확인할 수 있도록 함 
- AI가 인식하기 좋은 형식에 맞춰 작성해야 요청사항에 대한 구현 정확도가 올라갈 것이므로, description 사용해 내용 입력
   시에도 형식을 검토할 수 있도록 함

## 🔍 관련 이슈
- Closes #27 