### PR TITLE
[feature] 원형 버튼 컴포넌트 제작

### DIFF
--- a/src/components/ui/circleButton/CircleButton.styles.ts
+++ b/src/components/ui/circleButton/CircleButton.styles.ts
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+
+export const Button = styled.button<{ backgroundColor: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-width: 48px;
+  min-height: 48px;
+  border: none;
+  border-radius: 999px;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  cursor: pointer;
+  transition: filter 0.15s ease;
+
+  &:active {
+    filter: brightness(0.9);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.primary400};
+    outline-offset: 2px;
+  }
+`;
+
+export const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/ui/circleButton/CircleButton.styles.ts
+++ b/src/components/ui/circleButton/CircleButton.styles.ts
@@ -4,10 +4,9 @@ export const Button = styled.button<{ backgroundColor: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 100%;
-  min-width: 48px;
-  min-height: 48px;
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
   border: none;
   border-radius: 999px;
   background-color: ${({ backgroundColor }) => backgroundColor};

--- a/src/components/ui/circleButton/CircleButton.tsx
+++ b/src/components/ui/circleButton/CircleButton.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import * as S from "./CircleButton.styles";
+
+interface CircleButtonProps {
+  /** 버튼 배경색 (hex) */
+  backgroundColor: string;
+  /** 버튼 내부 아이콘 */
+  icon: ReactNode;
+  /** 접근성 레이블 */
+  ariaLabel: string;
+  /** 클릭 이벤트 */
+  onClick?: () => void;
+}
+
+const CircleButton = ({ backgroundColor, icon, ariaLabel, onClick }: CircleButtonProps) => {
+  return (
+    <S.Button
+      backgroundColor={backgroundColor}
+      aria-label={ariaLabel}
+      onClick={onClick}
+      type="button"
+    >
+      <S.IconWrapper aria-hidden={true}>{icon}</S.IconWrapper>
+    </S.Button>
+  );
+};
+
+export default CircleButton;

--- a/src/components/ui/circleButton/CircleButton.tsx
+++ b/src/components/ui/circleButton/CircleButton.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
 import * as S from "./CircleButton.styles";
 
 interface CircleButtonProps {
@@ -7,12 +7,12 @@ interface CircleButtonProps {
   /** 버튼 내부 아이콘 */
   icon: ReactNode;
   /** 접근성 레이블 */
-  ariaLabel: string;
+  "aria-label": string;
   /** 클릭 이벤트 */
-  onClick?: () => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-const CircleButton = ({ backgroundColor, icon, ariaLabel, onClick }: CircleButtonProps) => {
+const CircleButton = ({ backgroundColor, icon, "aria-label": ariaLabel, onClick }: CircleButtonProps) => {
   return (
     <S.Button
       backgroundColor={backgroundColor}

--- a/src/stories/components/CircleButton.stories.tsx
+++ b/src/stories/components/CircleButton.stories.tsx
@@ -48,7 +48,7 @@ const meta: Meta<typeof CircleButton> = {
       description: "버튼 내부 아이콘 (ReactNode)",
       control: false,
     },
-    ariaLabel: {
+    "aria-label": {
       control: "text",
       description: "접근성 레이블",
     },
@@ -74,7 +74,7 @@ export const KakaoButton: Story = {
   args: {
     backgroundColor: "#fee500",
     icon: <KakaoIcon />,
-    ariaLabel: "카카오톡으로 공유",
+    "aria-label": "카카오톡으로 공유",
   },
 };
 
@@ -82,6 +82,6 @@ export const LinkButton: Story = {
   args: {
     backgroundColor: "#e1e1e1",
     icon: <LinkIcon />,
-    ariaLabel: "링크 복사",
+    "aria-label": "링크 복사",
   },
 };

--- a/src/stories/components/CircleButton.stories.tsx
+++ b/src/stories/components/CircleButton.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import CircleButton from "../../components/ui/circleButton/CircleButton";
+
+const KakaoIcon = () => (
+  <svg
+    width="28px"
+    height="28px"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path
+      d="M12 3C6.477 3 2 6.477 2 10.8c0 2.7 1.554 5.086 3.924 6.548l-.998 3.73a.3.3 0 0 0 .46.325l4.54-3.01A11.93 11.93 0 0 0 12 18.6c5.523 0 10-3.477 10-7.8S17.523 3 12 3z"
+      fill="#000000"
+    />
+  </svg>
+);
+
+const LinkIcon = () => (
+  <svg
+    width="28px"
+    height="28px"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="#696969"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+);
+
+const meta: Meta<typeof CircleButton> = {
+  title: "Component/CircleButton",
+  component: CircleButton,
+  tags: ["autodocs"],
+  argTypes: {
+    backgroundColor: {
+      control: "color",
+      description: "버튼 배경색 (hex)",
+    },
+    icon: {
+      description: "버튼 내부 아이콘 (ReactNode)",
+      control: false,
+    },
+    ariaLabel: {
+      control: "text",
+      description: "접근성 레이블",
+    },
+    onClick: {
+      action: "clicked",
+      description: "클릭 이벤트",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 48, height: 48 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CircleButton>;
+
+export const KakaoButton: Story = {
+  args: {
+    backgroundColor: "#fee500",
+    icon: <KakaoIcon />,
+    ariaLabel: "카카오톡으로 공유",
+  },
+};
+
+export const LinkButton: Story = {
+  args: {
+    backgroundColor: "#e1e1e1",
+    icon: <LinkIcon />,
+    ariaLabel: "링크 복사",
+  },
+};


### PR DESCRIPTION
## 📌 요약
 카카오톡 공유 및 링크 복사 등 다양한 용도로 확장 가능한 범용 원형 버튼 컴포넌트를 구현

## ✨ 변경 사항
- 원형 버튼 컴포넌트 제작 및 스토리북 제작

이슈 대비 변경사항:                                                                                                  
- onClick prop 추가 (optional): 나중에 기능 붙일 때 컴포넌트 수정 없이 바로 사용 가능하도록 미리 선언함                
- :active 눌림 효과 추가 (filter: brightness(0.9)): 버튼 누를 때 최소한의 시각적 피드백 제공을 위함                    
- 버튼 크기 48x48로 설정: 피그마 기준 32x32였으나 모바일 터치 최소 권장 크기(48px) 기준 적용해 수정함                      
- 아이콘 크기 28px로 고정: 버튼 48px 기준 적절한 비율로 명시적 px 를 설정함  

## 🔍 관련 이슈
- Closes #29 

## 🧪 테스트
- [x] 스토리북에서 정상 동작 확인

## 📝 기타 참고 사항
- onClick 기능(카카오 공유, 링크 복사) 구현은 추후 별도 이슈로 진행 예정